### PR TITLE
fix: set keyring backend to test for stargate

### DIFF
--- a/internal/faucet/key.go
+++ b/internal/faucet/key.go
@@ -2,14 +2,14 @@ package faucet
 
 func (f *Faucet) loadKey() error {
 	if !f.keyExists(f.keyName) && f.keyMnemonic != "" {
-		if _, err := f.cliexec([]string{"keys", "add", f.keyName, "--recover"}, f.keyMnemonic, f.keyringPassword, f.keyringPassword); err != nil {
+		if _, err := f.cliexec([]string{"keys", "add", f.keyName, "--recover", "--keyring-backend", "test"}, f.keyMnemonic, f.keyringPassword, f.keyringPassword); err != nil {
 			return err
 		}
 	}
 
 	var err error
 
-	f.faucetAddress, err = f.cliexec([]string{"keys", "show", f.keyName, "-a"}, f.keyringPassword)
+	f.faucetAddress, err = f.cliexec([]string{"keys", "show", f.keyName, "-a", "--keyring-backend", "test"}, f.keyringPassword)
 	if err != nil {
 		return err
 	}
@@ -18,7 +18,7 @@ func (f *Faucet) loadKey() error {
 }
 
 func (f *Faucet) keyExists(keyname string) bool {
-	if _, err := f.cliexec([]string{"keys", "show", keyname}, f.keyringPassword); err != nil {
+	if _, err := f.cliexec([]string{"keys", "show", keyname, "--keyring-backend", "test"}, f.keyringPassword); err != nil {
 		return false
 	}
 

--- a/internal/faucet/tx.go
+++ b/internal/faucet/tx.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (f *Faucet) Send(recipient string) error {
-	_, err := f.cliexec([]string{"tx", "bank", "send", f.keyName, recipient,
+	_, err := f.cliexec([]string{"tx", "bank", "send", "--keyring-backend", "test", f.keyName, recipient,
 		fmt.Sprintf("%d%s", f.creditAmount, f.denom), "--yes", "--chain-id", f.chainID},
 		f.keyringPassword, f.keyringPassword, f.keyringPassword)
 


### PR DESCRIPTION
We don't have config with stargate where we can tell to use the test keyring-backend.
Therefore, we must provide this option for `tx` and `keys` command